### PR TITLE
Update scripts.nix "run" to handle arguments.

### DIFF
--- a/nix/scripts.nix
+++ b/nix/scripts.nix
@@ -12,7 +12,7 @@ let
   '';
   run = pkgs.writeShellScriptBin "run" ''
     set -euo pipefail
-    result/bin/replaceme
+    result/bin/replaceme $@
   '';
 in
 [ logo build run ]

--- a/nix/scripts.nix
+++ b/nix/scripts.nix
@@ -12,7 +12,7 @@ let
   '';
   run = pkgs.writeShellScriptBin "run" ''
     set -euo pipefail
-    result/bin/replaceme $@
+    result/bin/replaceme "$@"
   '';
 in
 [ logo build run ]


### PR DESCRIPTION
Currently, trying to pass arguments to a generated binary always fails. Adding `$@` should work for most use cases where the resulting binary expects arguments. It also gracefully handles not passing any arguments.