### PR TITLE
Make Nix handle dependencies

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -8,3 +8,7 @@ package *
 -- tell ghc to write the package environment file
 write-ghc-environment-files: always
 
+-- Nix handles dependencies. 
+-- It is generally a bug if cabal has to download anything
+-- In other words ~/.cabal should be empty (modulo some meta files)
+active-repositories: none

--- a/package.yaml
+++ b/package.yaml
@@ -41,8 +41,6 @@ tests:
     dependencies:
       - hspec
       - replaceme
-    verbatim:
-      build-tool-depends: hspec-discover:hspec-discover == 2.*
 
 default-extensions:
   - BangPatterns


### PR DESCRIPTION
Forcing Cabal to not implicitly download anything.

Closes https://github.com/pwm/nixkell/issues/15
