### PR TITLE
Bump nixplgs and GHC to 9.8.2

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -18,7 +18,7 @@ write-ghc-environment-files: always
 -- CI Nix builds are unaffected by this and will use the default -O1
 optimization: False
 
--- Nix handles dependencies. 
+-- Nix handles dependencies.
 -- It is generally a bug if cabal has to download anything
 -- In other words ~/.cabal should be empty (modulo some meta files)
 active-repositories: none

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -49,6 +49,10 @@ let
     depsFromDir = hlib.packagesFromDirectory { directory = ./packages; };
 
     manual = hfinal: hprev: {
+      cabal-install = util.patch hprev.cabal-install [
+        ./patches/prevent_missing_index_error.patch
+      ];
+
       haskell-language-server = hlsDisablePlugins hprev.haskell-language-server
         conf.hls.disable_plugins;
 

--- a/nix/patches/prevent_missing_index_error.patch
+++ b/nix/patches/prevent_missing_index_error.patch
@@ -1,0 +1,30 @@
+From ec242b1cb21e450d5212efd5c445f0d70786092e Mon Sep 17 00:00:00 2001
+From: Rebecca Turner <rbt@sent.as>
+Date: Tue, 27 Aug 2024 13:08:48 -0700
+Subject: [PATCH] Don't error if package index is missing
+
+All of the packages Cabal needs may already be present in the local
+package database; we don't know yet!
+
+This is a partial revert of #8944.
+
+See: https://github.com/haskell/cabal/pull/8944#issuecomment-2313147439
+---
+ src/Distribution/Client/IndexUtils.hs | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/Distribution/Client/IndexUtils.hs b/src/Distribution/Client/IndexUtils.hs
+index 2dc7d37e29c..0a6e6b40523 100644
+--- a/src/Distribution/Client/IndexUtils.hs
++++ b/src/Distribution/Client/IndexUtils.hs
+@@ -460,8 +460,8 @@ readRepoIndex verbosity repoCtxt repo idxState =
+       if isDoesNotExistError e
+         then do
+           case repo of
+-            RepoRemote{..} -> dieWithException verbosity $ MissingPackageList repoRemote
+-            RepoSecure{..} -> dieWithException verbosity $ MissingPackageList repoRemote
++            RepoRemote{..} -> warn verbosity $ exceptionMessageCabalInstall $ MissingPackageList repoRemote
++            RepoSecure{..} -> warn verbosity $ exceptionMessageCabalInstall $ MissingPackageList repoRemote
+             RepoLocalNoIndex local _ ->
+               warn verbosity $
+                 "Error during construction of local+noindex "

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,26 +1,26 @@
 {
-    "gitignore": {
-        "branch": "master",
-        "description": "Nix function for filtering local git sources",
-        "homepage": "",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "43e1aa1308018f37118e34d3a9cb4f5e75dc11d5",
-        "sha256": "1rlja3ba9s1n0icy3aarwhx9hk1jyfgngzizbn1afwwdlpvdlqw0",
-        "type": "tarball",
-        "url": "https://github.com/hercules-ci/gitignore.nix/archive/43e1aa1308018f37118e34d3a9cb4f5e75dc11d5.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "nixpkgs": {
-        "branch": "nixos-unstable",
-        "description": "Nix Packages collection",
-        "homepage": "",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f8e2ebd66d097614d51a56a755450d4ae1632df1",
-        "sha256": "03cxv9h218dj7kc5hb0yrclshgbq20plyrvnfdaw5payyy9gbsfr",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/f8e2ebd66d097614d51a56a755450d4ae1632df1.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    }
+  "gitignore": {
+    "branch": "master",
+    "description": "Nix function for filtering local git sources",
+    "homepage": "",
+    "owner": "hercules-ci",
+    "repo": "gitignore.nix",
+    "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+    "sha256": "02wxkdpbhlm3yk5mhkhsp3kwakc16xpmsf2baw57nz1dg459qv8w",
+    "type": "tarball",
+    "url": "https://github.com/hercules-ci/gitignore.nix/archive/637db329424fd7e46cf4185293b9cc8c88c95394.tar.gz",
+    "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+  },
+  "nixpkgs": {
+    "branch": "nixos-unstable",
+    "description": "Nix Packages collection",
+    "homepage": "",
+    "owner": "NixOS",
+    "repo": "nixpkgs",
+    "rev": "c95b3e3904d1c3138cafab0ddfbc08336128f664",
+    "sha256": "03b5i7almr4v68b677qqnbyvrmqdxq02gks7q1jr6kfm2j51bgw5",
+    "type": "tarball",
+    "url": "https://github.com/NixOS/nixpkgs/archive/c95b3e3904d1c3138cafab0ddfbc08336128f664.tar.gz",
+    "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+  }
 }

--- a/nix/util.nix
+++ b/nix/util.nix
@@ -44,4 +44,9 @@
       gitIgnore path type && !builtins.elem (baseNameOf path) files
       && !lib.any (d: lib.hasPrefix d (relToPath path)) paths;
     };
+
+  patch = name: patches:
+    name.overrideAttrs (prev: {
+      patches = prev.patches or [ ] ++ patches;
+    });
 }

--- a/nixkell.toml
+++ b/nixkell.toml
@@ -4,7 +4,7 @@
 # Warning: if you don't choose one from the currently available versions
 # https://github.com/NixOS/nixpkgs/tree/master/pkgs/development/compilers/ghc
 # you will most likely have to compile *everything* yourself.
-version = "9.4.8"
+version = "9.8.2"
 # optimise = true
 # profiling = false
 # benckmark = false
@@ -14,6 +14,7 @@ version = "9.4.8"
 
 # We want these tools to be built with our haskell
 haskell_tools = [
+  "cabal-install",
   "haskell-language-server",
   "hlint",
   "nixfmt",
@@ -21,7 +22,6 @@ haskell_tools = [
 ]
 
 tools = [
-  "cabal-install",
   "cabal2nix",
   "nil",
   "niv",
@@ -33,9 +33,9 @@ tools = [
 # List of plugins the you don't want to build
 [hls]
 disable_plugins = [
-  "fourmolu",
-  "floskell",
-  "stan",
+#  "fourmolu",
+#  "floskell",
+#  "stan",
 ]
 
 # These files and directories will be excluded from the nix build,


### PR DESCRIPTION
One unfortunate fallout from this bump was that cabal 3.12 broke the use
of `active-repositories: none` which was used to tell Cabal not to
manage package repositories (as we use Nix for that).

The fix for now is to patch `cabal-install` and revert the change that
made the previoud warning into an error.
